### PR TITLE
verify: Upgrade verus to official release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,24 +251,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "builtin"
-version = "0.1.0"
-source = "git+https://github.com/verus-lang/verus?rev=42e0507#42e050734071858e9fa2b6ae4298188e760888d0"
-
-[[package]]
-name = "builtin_macros"
-version = "0.1.0"
-source = "git+https://github.com/verus-lang/verus?rev=42e0507#42e050734071858e9fa2b6ae4298188e760888d0"
-dependencies = [
- "prettyplease_verus",
- "proc-macro2",
- "quote",
- "syn",
- "syn_verus",
- "synstructure 0.13.0",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,15 +1521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease_verus"
-version = "0.2.29"
-source = "git+https://github.com/verus-lang/verus?rev=42e0507#42e050734071858e9fa2b6ae4298188e760888d0"
-dependencies = [
- "proc-macro2",
- "syn_verus",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -1875,17 +1848,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "state_machines_macros"
-version = "0.1.0"
-source = "git+https://github.com/verus-lang/verus?rev=42e0507#42e050734071858e9fa2b6ae4298188e760888d0"
-dependencies = [
- "indexmap",
- "proc-macro2",
- "quote",
- "syn_verus",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,8 +1875,6 @@ dependencies = [
  "bitfield-struct 0.6.2",
  "bitflags 2.9.1",
  "bootlib",
- "builtin",
- "builtin_macros",
  "cocoon-tpm-crypto",
  "cocoon-tpm-tpm2-interface",
  "cocoon-tpm-utils-common",
@@ -1939,6 +1899,8 @@ dependencies = [
  "uuid",
  "verify_external",
  "verify_proof",
+ "verus_builtin",
+ "verus_builtin_macros",
  "verus_stub",
  "virtio-drivers",
  "vstd",
@@ -1966,33 +1928,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn_verus"
-version = "2.0.96"
-source = "git+https://github.com/verus-lang/verus?rev=42e0507#42e050734071858e9fa2b6ae4298188e760888d0"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.0"
-source = "git+https://github.com/mystor/synstructure.git?rev=1079497eb2bea252433dac53afe41291d8779641#1079497eb2bea252433dac53afe41291d8779641"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]
@@ -2189,12 +2130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,8 +2186,8 @@ checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 name = "verify_external"
 version = "0.1.0"
 dependencies = [
- "builtin",
- "builtin_macros",
+ "verus_builtin",
+ "verus_builtin_macros",
  "vstd",
 ]
 
@@ -2260,10 +2195,10 @@ dependencies = [
 name = "verify_proof"
 version = "0.1.0"
 dependencies = [
- "builtin",
- "builtin_macros",
  "seq-macro",
- "state_machines_macros",
+ "verus_builtin",
+ "verus_builtin_macros",
+ "verus_state_machines_macros",
  "vstd",
 ]
 
@@ -2274,6 +2209,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "verus_builtin"
+version = "0.0.0-2025-08-12-1837"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d00c22a221fbf8b3398002ebdd1c89017e5381c2f05d6933a3706d87e90e14"
+
+[[package]]
+name = "verus_builtin_macros"
+version = "0.0.0-2025-11-16-0050"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b81815a92a215853f2c9dc87967eac087c3a5126f0acc4c11c6175b9f2b633d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+ "verus_prettyplease",
+ "verus_syn",
+]
+
+[[package]]
 name = "verus_macro_stub"
 version = "0.1.0"
 dependencies = [
@@ -2281,12 +2236,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "verus_prettyplease"
+version = "0.0.0-2025-11-16-0050"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f6851d9ddf5bfdd1c7a7abff8cb797df18b67b80c3da35e0cbfa939d725ef1"
+dependencies = [
+ "proc-macro2",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_state_machines_macros"
+version = "0.0.0-2025-11-16-0050"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b5f719e2d4fc80ffcff723da75c31a7ea1419220627917e152b2d7cae2fbdc"
+dependencies = [
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "verus_syn",
+]
+
+[[package]]
 name = "verus_stub"
 version = "0.1.0"
 dependencies = [
- "builtin_macros",
+ "verus_builtin_macros",
  "verus_macro_stub",
  "vstd",
+]
+
+[[package]]
+name = "verus_syn"
+version = "0.0.0-2025-11-16-0050"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd239518d302792a2c1b2a6bfe2286268810b9627c5507fbc502ea3e88b805"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2301,12 +2289,13 @@ dependencies = [
 
 [[package]]
 name = "vstd"
-version = "0.1.0"
-source = "git+https://github.com/verus-lang/verus?rev=42e0507#42e050734071858e9fa2b6ae4298188e760888d0"
+version = "0.0.0-2025-11-16-0050"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78daf1e3f8fde46c7ccbdd80d1d95875d8be3fe9b02f5f827d798cbecad47893"
 dependencies = [
- "builtin",
- "builtin_macros",
- "state_machines_macros",
+ "verus_builtin",
+ "verus_builtin_macros",
+ "verus_state_machines_macros",
 ]
 
 [[package]]
@@ -2605,7 +2594,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -2667,7 +2656,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,10 +84,10 @@ uuid = { version = "1.6.1", default-features = false }
 zerocopy = { version = "0.8.2", features = ["derive"] }
 
 # Verus repos
-builtin = { git = "https://github.com/verus-lang/verus", rev ="42e0507", default-features = false }
-builtin_macros = { git = "https://github.com/verus-lang/verus", rev ="42e0507", features = ["vpanic"], default-features = false }
-state_machines_macros = { git = "https://github.com/verus-lang/verus", rev ="42e0507", default-features = false }
-vstd = { git = "https://github.com/verus-lang/verus", rev ="42e0507", features = ["alloc", "allow_panic"], default-features = false }
+verus_builtin = { version = "0.0.0-2025-08-12-1837", default-features = false }
+verus_builtin_macros = { version = "0.0.0-2025-11-16-0050", features = ["vpanic"], default-features = false }
+verus_state_machines_macros = { version = "0.0.0-2025-11-16-0050", default-features = false }
+vstd = { version = "0.0.0-2025-11-16-0050", features = ["alloc", "allow_panic"], default-features = false }
 
 # Verification libs
 verify_proof = { path = "verify_proof", default-features = false  }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -60,8 +60,8 @@ sha2 = { workspace = true, features = ["force-soft"] }
 uuid.workspace = true
 virtio-drivers = { workspace = true, optional = true }
 
-builtin = { workspace = true, optional = true }
-builtin_macros = { workspace = true, optional = true }
+verus_builtin = { workspace = true, optional = true }
+verus_builtin_macros = { workspace = true, optional = true }
 vstd = { workspace = true, optional = true}
 verify_proof = { workspace = true, optional = true}
 verify_external = { workspace = true, optional = true}
@@ -78,7 +78,7 @@ enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 vtpm = ["dep:libtcgtpm"]
 nosmep = []
 nosmap = []
-verus_all = ["builtin", "builtin_macros", "vstd", "verify_proof/verus", "verify_external/verus", "verus_stub/disable"]
+verus_all = ["verus_builtin", "verus_builtin_macros", "vstd", "verify_proof/verus", "verify_external/verus", "verus_stub/disable"]
 verus = ["verus_all", "verify_proof/noverify", "verify_external/noverify"]
 noverify = []
 virtio-drivers = ["dep:virtio-drivers"]

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -22,7 +22,7 @@ include!("address.verus.rs");
 // The backing type to represent an address;
 type InnerAddr = usize;
 
-#[verus_verify]
+#[verus_spec]
 const SIGN_BIT: usize = 47;
 
 #[inline]
@@ -316,6 +316,7 @@ impl ops::Add<InnerAddr> for PhysAddr {
     }
 }
 
+#[verus_verify]
 impl Address for PhysAddr {}
 
 #[verus_verify]

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -21,6 +21,7 @@ pub struct FixedAddressMappingRange {
     phys_start: PhysAddr,
 }
 
+#[verus_verify]
 impl FixedAddressMappingRange {
     #[verus_spec(ret =>
         requires

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -53,7 +53,7 @@ impl From<AllocError> for SvsmError {
 }
 
 /// Maximum order of page allocations (up to 128kb)
-#[verus_verify]
+#[verus_spec]
 pub const MAX_ORDER: usize = 6;
 
 /// Calculates the order of a given size for page allocation.
@@ -407,6 +407,7 @@ struct FileInfo {
     ref_count: u64,
 }
 
+#[verus_verify]
 impl FileInfo {
     /// Creates a new [`FileInfo`] with the specified reference count.
     #[verus_verify(dual_spec(spec_new))]

--- a/scripts/vinstall.sh
+++ b/scripts/vinstall.sh
@@ -5,27 +5,17 @@
 #
 # Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
 # A script to install verus tools
-VERISMO_REV=7545c6c
-VERUS_DIR=`cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "builtin_macros") | .targets[].src_path'| xargs dirname | xargs -I{} realpath {}/../../../`
+VERISMO_REV=ffee0c9
+VERUS_RUST_VERSION=1.91
 
-# Choose the Rust toolchain version that is compatible with verus.
-export RUSTUP_TOOLCHAIN=`grep '^channel' $VERUS_DIR/rust-toolchain.toml | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/'`
-RUSTUP_TARGET="x86_64-unknown-none"
-rustup target add "$RUSTUP_TARGET"
-
+# Install x86_64-unknown-none target for verus-compatible Rust version
+export RUSTUP_TOOLCHAIN=$VERUS_RUST_VERSION
+rustup target add x86_64-unknown-none
 # Install the verus toolchain
 cargo install --git https://github.com/microsoft/verismo/ --rev $VERISMO_REV cargo-v
-verus=$VERUS_DIR/source/target-verus/release/verus
-if [ -f ${verus} ]; then
-    echo "verus (${verus}) is already built"
-else
-    # build the verus using the source code from builtin/vstd defined in
-    # Cargo.toml so that the verus lib and tool are compatible.
-    cargo v prepare-verus
-fi
-
 # verus-rustc as a wrapper to call verus with proper rustc flags.
 cargo install --git https://github.com/microsoft/verismo/ --rev $VERISMO_REV verus-rustc
+cargo v install-verus
 
 # verus formatter
 cargo install --git https://github.com/verus-lang/verusfmt --rev v0.5.7

--- a/verify_external/Cargo.toml
+++ b/verify_external/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-builtin = { workspace = true, optional = true }
-builtin_macros = { workspace = true }
+verus_builtin = { workspace = true, optional = true }
+verus_builtin_macros = { workspace = true }
 vstd = { workspace = true, optional = true }
 
 [lints]
@@ -14,4 +14,4 @@ workspace = true
 [features]
 default = []
 noverify = []
-verus = ["builtin", "vstd"]
+verus = ["verus_builtin", "vstd"]

--- a/verify_external/src/lib.rs
+++ b/verify_external/src/lib.rs
@@ -22,7 +22,7 @@ pub mod hw_spec;
 
 pub mod ptr;
 
-use builtin_macros::*;
+use verus_builtin_macros::*;
 
 verus! {
 #[cfg_attr(verus_keep_ghost, verifier::broadcast_use_by_default_when_this_crate_is_imported)]

--- a/verify_proof/Cargo.toml
+++ b/verify_proof/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-builtin = { workspace = true, optional = true }
-builtin_macros = { workspace = true }
+verus_builtin = { workspace = true, optional = true }
+verus_builtin_macros = { workspace = true }
 vstd = { workspace = true, optional = true }
-state_machines_macros = { workspace = true }
+verus_state_machines_macros = { workspace = true }
 seq-macro = "0.3"
 
 [lints]
@@ -18,4 +18,4 @@ workspace = true
 [features]
 default = []
 noverify = []
-verus = ["builtin", "vstd"]
+verus = ["verus_builtin", "vstd"]

--- a/verify_proof/src/frac_perm.rs
+++ b/verify_proof/src/frac_perm.rs
@@ -8,7 +8,7 @@
 // This is motivated by PCM lib from vstd.
 // The state-machine proofs are motivated from the proof for Rc in vstd.
 use crate::sum::{lemma_sum_insert, lemma_sum_remove, sum, CountTrait};
-use state_machines_macros::*;
+use verus_state_machines_macros::*;
 use vstd::modes::tracked_swap;
 use vstd::multiset::*;
 use vstd::prelude::*;

--- a/verify_proof/src/frac_ptr.rs
+++ b/verify_proof/src/frac_ptr.rs
@@ -6,7 +6,7 @@
 //
 // A fully verified ghost and non-forgeable frac-based pointer permission to
 // share tracked memory permissions.
-use state_machines_macros::*;
+use verus_state_machines_macros::*;
 
 use vstd::prelude::*;
 use vstd::raw_ptr::{MemContents, PointsTo, PointsToData, PointsToRaw};

--- a/verify_proof/src/lib.rs
+++ b/verify_proof/src/lib.rs
@@ -8,7 +8,7 @@
 #![allow(unused_braces)]
 #![allow(unexpected_cfgs)]
 #![allow(missing_debug_implementations)]
-use builtin_macros::*;
+use verus_builtin_macros::*;
 
 pub mod bits;
 #[cfg(verus_keep_ghost)]

--- a/verus_stub/Cargo.toml
+++ b/verus_stub/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 
 [dependencies]
 
-builtin_macros = { workspace = true, optional = true }
+verus_builtin_macros = { workspace = true, optional = true }
 vstd = { workspace = true, optional = true }
 verus_macro_stub = { workspace = true, optional = true}
 
 [features]
 default = ["dep:verus_macro_stub"]
-disable = ["builtin_macros", "vstd"]
+disable = ["verus_builtin_macros", "vstd"]
 
 [lints]
 workspace = true

--- a/verus_stub/src/lib.rs
+++ b/verus_stub/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 #[cfg(feature = "disable")]
-pub use builtin_macros::*;
+pub use verus_builtin_macros::*;
 
 #[cfg(feature = "disable")]
 pub use vstd::prelude::*;


### PR DESCRIPTION
* Update verus builtin crate names
* Update some annotations since latest verus handles const items in a slightly different ways.
* Add verus_verify for all Impl item since it is ignored if not marked as verus_verify in latest verus.